### PR TITLE
Remove Upbound registry, push only to GHCR on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,8 @@ env:
   XP_CHANNEL: master   # TODO(negz): Pin to stable once v1.14 is released.
   XP_VERSION: current  # TODO(negz): Pin to a version once v1.14 is released.
 
-  # This CI job will automatically push new builds to xpkg.upbound.io if the
-  # XPKG_ACCESS_ID and XPKG_TOKEN secrets are set in the GitHub respository (or
-  # organization) settings. Create a token at https://accounts.upbound.io.
-  XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
-
-  # The package to push, without a version tag. The default matches GitHub. For
-  # example xpkg.upbound.io/crossplane/function-template-go.
-  XPKG: xpkg.upbound.io/${{ github.repository}}
-  CROSSPLANE_REGORG: ghcr.io/${{ github.repository}} # xpkg.crossplane.io/crossplane-contrib
+  # The package to push to GHCR
+  CROSSPLANE_REGORG: ghcr.io/${{ github.repository}}
 
   # The package version to push. The default is 0.0.0-gitsha.
   XPKG_VERSION: ${{ inputs.version }}
@@ -148,14 +141,6 @@ jobs:
       - name: Setup the Crossplane CLI
         run: "curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
 
-      - name: Login to Upbound
-        uses: docker/login-action@v3
-        if: env.XPKG_ACCESS_ID != ''
-        with:
-          registry: xpkg.upbound.io
-          username: ${{ secrets.XPKG_ACCESS_ID }}
-          password: ${{ secrets.XPKG_TOKEN }}
-
       # If a version wasn't explicitly passed as a workflow_dispatch input we
       # default to version v0.0.0-<git-commit-date>-<git-short-sha>, for example
       # v0.0.0-20231101115142-1091066df799. This is a simple implementation of
@@ -163,10 +148,6 @@ jobs:
       - name: Set Default Multi-Platform Package Version
         if: env.XPKG_VERSION == ''
         run: echo "XPKG_VERSION=v0.0.0-$(date -d@$(git show -s --format=%ct) +%Y%m%d%H%M%S)-$(git rev-parse --short=12 HEAD)" >> $GITHUB_ENV
-
-      - name: Push Multi-Platform Package to Upbound
-        if: env.XPKG_ACCESS_ID != ''
-        run: "./crossplane --verbose xpkg push --package-files $(echo *.xpkg|tr ' ' ,) ${{ env.XPKG }}:${{ env.XPKG_VERSION }}"
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -176,5 +157,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Multi-Platform Package to GHCR
-        if: env.XPKG_ACCESS_ID != ''
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/')) && github.repository_owner == 'crossplane-contrib'
         run: "./crossplane --verbose xpkg push --package-files $(echo *.xpkg|tr ' ' ,) ${{ env.CROSSPLANE_REGORG }}:${{ env.XPKG_VERSION }}"


### PR DESCRIPTION
Streamline CI workflow to only push packages to GitHub Container Registry. Remove all Upbound registry integration and only push on main branch in crossplane-contrib org.